### PR TITLE
update ghidra dependencies to latest openjdk

### DIFF
--- a/ghidra/ghidra.nuspec
+++ b/ghidra/ghidra.nuspec
@@ -24,7 +24,7 @@
       In support of NSA's Cybersecurity mission, Ghidra was built to solve scaling and teaming problems on complex SRE efforts, and to provide a customizable and extensible SRE research platform. NSA has applied Ghidra SRE capabilities to a variety of problems that involve analyzing malicious code and generating deep insights for SRE analysts who seek a better understanding of potential vulnerabilities in networks and systems.
     </description>
     <dependencies>
-      <dependency id="openjdk11" version="11.0" />
+      <dependency id="openjdk11" />
     </dependencies>
   </metadata>
   <files>

--- a/ghidra/ghidra.nuspec
+++ b/ghidra/ghidra.nuspec
@@ -24,7 +24,7 @@
       In support of NSA's Cybersecurity mission, Ghidra was built to solve scaling and teaming problems on complex SRE efforts, and to provide a customizable and extensible SRE research platform. NSA has applied Ghidra SRE capabilities to a variety of problems that involve analyzing malicious code and generating deep insights for SRE analysts who seek a better understanding of potential vulnerabilities in networks and systems.
     </description>
     <dependencies>
-      <dependency id="openjdk11" />
+      <dependency id="openjdk" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
ghidra 10.2 requires JDK >= 17, not 11.

Not sure what your policy is on pinning older versions, but the latest one will work just fine.