### PR TITLE
Remove Url parameter with empty value

### DIFF
--- a/azure-cosmosdb-emulator/tools/chocolateyInstall.ps1
+++ b/azure-cosmosdb-emulator/tools/chocolateyInstall.ps1
@@ -3,7 +3,6 @@
 $packageArgs = @{
     packageName    = $env:ChocolateyPackageName
     fileType       = 'msi'
-    url            = ''
     url64bit       = 'https://cdbemulator-dmhwaeevbhd3e9f8.b02.azurefd.net/msi/pipeline/azure-cosmosdb-emulator-2.14.23-19d5c986.msi'
     softwareName   = 'Azure Cosmos DB Emulator'
     checksum64     = 'dd5e8f976f5a6693f3bbaf9cd6d64d99a0008abd34c1416a978a402c80b266b7'


### PR DESCRIPTION
The azure-cosmosdb-emulator package is currently awaiting moderation in Chocolatey as the validation fails.
Their [documentation](https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0073/) say that they validate that if you pass Url, you must also pass Checksum. And that if you pass Url64bit that you also pass Checksum64.

Before this change, the script was passing an empty Url without a Checksum parameter, so this is likely the reason that it fails validation (while I'm not 100% sure that this is how the validation logic is working on their end).
This avoids passing Url entirely, since Url isn't a required argument: https://docs.chocolatey.org/en-us/create/functions/install-chocolateypackage/#-url-string