### PR TITLE
Adjust silent flags for the Raspberry Pi Imager Chocolatey package

### DIFF
--- a/rpi-imager/tools/chocolateyInstall.ps1
+++ b/rpi-imager/tools/chocolateyInstall.ps1
@@ -10,7 +10,7 @@ $packageArgs = @{
     softwareName   = 'Raspberry Pi Imager'
     checksum       = '2c77d0c513dd51e67ae7c362a581f72373a9e4ab22a31344123b1f3de56f748d'
     checksumType   = 'sha256'
-    silentArgs     = '/S'
+    silentArgs     = '/verysilent'
     validExitCodes = @(0)
 }
 

--- a/rpi-imager/tools/chocolateyuninstall.ps1
+++ b/rpi-imager/tools/chocolateyuninstall.ps1
@@ -8,7 +8,7 @@ if ($key.Count -eq 1) {
         $packageArgs = @{
             packageName    = $packageName
             fileType       = 'EXE'
-            silentArgs     = '/S'
+            silentArgs     = '/verysilent'
             validExitCodes = @(0)
             file           = "$($_.UninstallString)"
         }


### PR DESCRIPTION
Hi there,

The rpi-imager package is currently stuck in moderation on Chocolatey because the validation step fails. It looks like the silent flag behavior has changed in recent versions of the Raspberry Pi Imager.

This PR updates the install script to use /verysilent instead of /S, which avoids the installer popups.

Thanks for maintaining the package! 😊